### PR TITLE
Change extraEnv indentation and add a test for lint.

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -22,3 +22,9 @@
 *.tmproj
 .vscode/
 charts
+.github
+.helmignore
+Makefile
+*.md
+robots.txt
+/test

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.38
+version: 1.1.39
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 lint:
 	helm lint .
+	helm lint --values test/extraenv.yaml .
 
 build:
 	helm package .

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -131,7 +131,7 @@ spec:
           {{- end }}
 
           {{- if .Values.extraEnv }}
-          {{- toYaml .Values.extraEnv | nindent 5 }}
+          {{- toYaml .Values.extraEnv | nindent 10 }}
           {{- end }}
           ports:
             - name: http

--- a/test/extraenv.yaml
+++ b/test/extraenv.yaml
@@ -1,0 +1,6 @@
+authorizer:
+  database_type: mongodb
+  database_url: mongodb+srv://name:password@some-mongo.com
+extraEnv:
+- name: DATABASE_NAME
+  value: some_name


### PR DESCRIPTION
Indentation for extraEnv from values was off and deployment failed. I added test case for "make lint" to verify that the change works.  Also more files to be ignored by Helm.