### PR TITLE
chart: surface April 2026 security hardening flags

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -78,6 +78,14 @@ spec:
                 --host="${HOST:-0.0.0.0}" \
                 --http-port="${PORT:-8080}" \
                 --metrics-port="${METRICS_PORT:-8081}" \
+                --trusted-proxies="${TRUSTED_PROXIES}" \
+                --refresh-token-expires-in="${REFRESH_TOKEN_EXPIRES_IN:-2592000}" \
+                --enable-hsts="${ENABLE_HSTS:-false}" \
+                --disable-csp="${DISABLE_CSP:-false}" \
+                --graphql-max-complexity="${GRAPHQL_MAX_COMPLEXITY:-300}" \
+                --graphql-max-depth="${GRAPHQL_MAX_DEPTH:-15}" \
+                --graphql-max-aliases="${GRAPHQL_MAX_ALIASES:-30}" \
+                --graphql-max-body-bytes="${GRAPHQL_MAX_BODY_BYTES:-1048576}" \
                 --log-level="${LOG_LEVEL:-info}" \
                 --enable-login-page="${ENABLE_LOGIN_PAGE:-true}" \
                 --enable-playground="${ENABLE_PLAYGROUND:-true}" \
@@ -345,6 +353,29 @@ spec:
           - name: "SENDER_NAME"
             value: "{{ .Values.authorizer.smtp_sender_name }}"
           {{- end }}
+
+          # April 2026 security hardening flags. See values.yaml for the
+          # operational notes attached to each one.
+          {{- if .Values.authorizer.trusted_proxies }}
+          - name: "TRUSTED_PROXIES"
+            value: {{ .Values.authorizer.trusted_proxies | quote }}
+          {{- end }}
+          {{- if .Values.authorizer.refresh_token_expires_in }}
+          - name: "REFRESH_TOKEN_EXPIRES_IN"
+            value: {{ .Values.authorizer.refresh_token_expires_in | toString | quote }}
+          {{- end }}
+          - name: "ENABLE_HSTS"
+            value: {{ .Values.authorizer.enable_hsts | default false | toString | quote }}
+          - name: "DISABLE_CSP"
+            value: {{ .Values.authorizer.disable_csp | default false | toString | quote }}
+          - name: "GRAPHQL_MAX_COMPLEXITY"
+            value: {{ .Values.authorizer.graphql_max_complexity | default 300 | toString | quote }}
+          - name: "GRAPHQL_MAX_DEPTH"
+            value: {{ .Values.authorizer.graphql_max_depth | default 15 | toString | quote }}
+          - name: "GRAPHQL_MAX_ALIASES"
+            value: {{ .Values.authorizer.graphql_max_aliases | default 30 | toString | quote }}
+          - name: "GRAPHQL_MAX_BODY_BYTES"
+            value: {{ int64 (default 1048576 .Values.authorizer.graphql_max_body_bytes) | toString | quote }}
 
           {{- if .Values.extraEnv }}
           {{- toYaml .Values.extraEnv | nindent 10 }}

--- a/values.yaml
+++ b/values.yaml
@@ -137,7 +137,11 @@ authorizer:
   # OAuth client secret (required)
   client_secret: null
 
-  # Admin secret
+  # Admin secret (--admin-secret).
+  # REQUIRED, non-empty. As of the April 2026 security release the
+  # authorizer binary refuses to start when --admin-secret is empty —
+  # the previous insecure "password" default has been removed. Pick any
+  # non-empty value; the strength of the secret is your responsibility.
   admin_secret: null
 
   # JWT type (e.g. HS256, RS256)
@@ -181,3 +185,39 @@ authorizer:
 
   # SMTP sender name
   smtp_sender_name: null
+
+  # ----------------------------------------------------------------------
+  # April 2026 security hardening flags
+  # ----------------------------------------------------------------------
+
+  # Trusted reverse-proxy networks (--trusted-proxies). Comma-separated CIDRs.
+  # Empty (the default) means gin uses RemoteAddr and ignores X-Forwarded-For
+  # — safe out of the box. If Authorizer is behind an ingress controller,
+  # nginx, Cloudflare, etc., set this to the proxy network or per-IP rate
+  # limiting and audit logs will key on the proxy IP. See
+  # https://docs.authorizer.dev/core/security#trusted-proxies
+  trusted_proxies: null
+
+  # Refresh-token lifetime in seconds (--refresh-token-expires-in).
+  # Default 30 days (2592000). Shorten for higher-security deployments;
+  # lengthen for long-lived sessions.
+  refresh_token_expires_in: null
+
+  # Strict-Transport-Security response header (--enable-hsts).
+  # Off by default — only enable behind TLS, otherwise browsers will be
+  # locked out for a year (max-age=31536000).
+  enable_hsts: false
+
+  # Disable the default Content-Security-Policy header (--disable-csp).
+  # CSP is on by default with a conservative policy. Set true ONLY as an
+  # escape hatch if the default policy breaks a customised dashboard.
+  disable_csp: false
+
+  # GraphQL query limits (--graphql-max-*). Defaults are conservative;
+  # raise individually if your legitimate operation surface needs them.
+  # Rejections are emitted as the authorizer_graphql_limit_rejections_total
+  # Prometheus counter, labelled by the limit kind that tripped.
+  graphql_max_complexity: 300
+  graphql_max_depth: 15
+  graphql_max_aliases: 30
+  graphql_max_body_bytes: 1048576


### PR DESCRIPTION
## Summary
Surfaces the new CLI flags from authorizerdev/authorizer PRs #582–#590 (April 2026 security hardening) as values.yaml fields.

New \`authorizer:\` fields:
- \`trusted_proxies\` — comma-separated CIDRs of reverse proxies whose X-Forwarded-For will be honoured. The new binary defaults to "trust nothing"; operators behind an ingress / nginx / Cloudflare must set this explicitly or per-IP rate limiting and audit logs will key on the proxy IP. See [Trusted proxies](https://docs.authorizer.dev/core/security#trusted-proxies).
- \`refresh_token_expires_in\` — refresh-token lifetime in seconds (default 30 days, previously hardcoded).
- \`enable_hsts\` (default false) — opt-in HSTS, only safe behind TLS.
- \`disable_csp\` (default false) — escape hatch for the default CSP.
- \`graphql_max_complexity\` / \`graphql_max_depth\` / \`graphql_max_aliases\` / \`graphql_max_body_bytes\` — GraphQL query DoS limits (defaults 300 / 15 / 30 / 1 MiB).

Also notes in the \`admin_secret\` comment that the field is now **required and non-empty**: the new binary refuses to start when \`--admin-secret\` is empty (the previous \`"password"\` default is gone). Operators upgrading from a chart install that left \`admin_secret: null\` will see a startup failure unless they set it.

## Coordination note
There is an in-flight WIP on \`main\` (uncommitted) that adds the metrics + rate-limit value fields and bumps the chart to 2.0.2. This PR intentionally leaves \`Chart.yaml\` untouched so the maintainer can decide how to interleave the two changes (likely: land the WIP as 2.0.2, then this as 2.0.3).

## Test plan
- [x] \`helm lint .\` — passes
- [x] \`helm template .\` with \`trusted_proxies\` set — renders the new flags and env vars correctly
- [x] \`GRAPHQL_MAX_BODY_BYTES\` renders as integer string (\`"1048576"\`), not scientific notation
- [ ] Install on a real cluster and verify the env vars reach the pod