### PR TITLE
fix: pull helm test image from quay, not docker hub

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.0
+version: 2.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Helm chart for [Authorizer](https://authorizer.dev) — an open-source, self-hos
 
 This chart deploys the Authorizer binary as a Kubernetes `Deployment`, wires up a `Service` (HTTP + optional gRPC port), optional metrics infrastructure, and exposes all server flags as `values.yaml` keys.
 
-Chart version: **2.2.0** | App version: **2.3.0**
+Chart version: **2.2.1** | App version: **2.3.0**
 
 ## Getting Started
 

--- a/templates/tests/test-connection.yaml
+++ b/templates/tests/test-connection.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: busybox
+      image: quay.io/quay/busybox:latest
       command:
         - sh
         - -c


### PR DESCRIPTION
The chart pulled every image from quay except one: the `helm test` hook used `image: busybox` — Docker Hub, and unpinned. Anonymous Docker Hub pull limits can fail `helm test` in CI or in clusters without a Docker Hub pull secret.

- `templates/tests/test-connection.yaml`: `busybox` → `quay.io/quay/busybox:latest`
- chart `2.2.0` → `2.2.1` (template change), README chart version updated

## Verification (kind, `authorizer-issue8`)

- installed published `authorizer/authorizer` 2.2.0 from `https://helm-charts.authorizer.dev`, then upgraded to this build: `STATUS: deployed`
- `helm test` → `Phase: Succeeded` with the quay image
- `quay.io/quay/busybox:latest` confirmed to have working `wget`/`sh`: `wget -qO- http://authorizer:80/healthz` → `{"status":"ok"}`
- rendered manifests now contain exactly two images, both on quay:
  - `quay.io/authorizer/authorizer:2.3.0`
  - `quay.io/quay/busybox:latest`
- `helm lint` clean

Merging this publishes 2.2.1 automatically via the workflow added in #9.

Note: #7 also edits the `version:` line in `Chart.yaml` (2.2.0 → 2.3.0), so it will need a one-line conflict resolution after this lands.