### PR TITLE
fix: drop [skip ci] from publish commit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,5 +27,8 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add "charts/authorizer-${version}.tgz" index.yaml
-          git commit -m "chore: publish chart ${version} [skip ci]"
+          # No [skip ci]: Netlify honours it and would not deploy the new chart.
+          # Loop-safe anyway — GITHUB_TOKEN pushes do not trigger workflows, and
+          # the guard above makes a re-run a no-op.
+          git commit -m "chore: publish chart ${version}"
           git push


### PR DESCRIPTION
Follow-up to #9. The publish workflow ran correctly on the #10 merge — packaged `authorizer-2.2.1.tgz`, reindexed, committed and pushed `fa70def..5553687`. But the chart was still 404 on the site.

Cause: the commit message carried `[skip ci]`, and **Netlify honours it**. The artifacts reached `main` but no deploy ran, so the site kept serving the previous build:

- `https://helm-charts.authorizer.dev/Chart.yaml` → `version: 2.2.1` (deployed by the #10 merge)
- `https://helm-charts.authorizer.dev/charts/authorizer-2.2.1.tgz` → **404** (published by the skipped commit)
- `charts/authorizer-2.2.1.tgz` present on `main`, 16425 bytes

`[skip ci]` was never needed for loop safety: pushes made with `GITHUB_TOKEN` do not trigger workflow runs, and the `if [ -f "charts/authorizer-${version}.tgz" ]` guard makes any re-run a no-op.

Merging this also deploys the already-committed 2.2.1 tarball.