### PR TITLE
fix: only pass --mcp-enabled when mcp_enabled is set

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -130,7 +130,7 @@ spec:
                 --grpc-insecure="${GRPC_INSECURE:-false}" \
                 --grpc-tls-cert="${GRPC_TLS_CERT}" \
                 --grpc-tls-key="${GRPC_TLS_KEY}" \
-                --mcp-enabled="${MCP_ENABLED:-false}" \
+                ${MCP_ENABLED:+--mcp-enabled="$MCP_ENABLED"} \
                 --rate-limit-rps="${RATE_LIMIT_RPS}" \
                 --rate-limit-burst="${RATE_LIMIT_BURST}" \
                 --rate-limit-fail-closed="${RATE_LIMIT_FAIL_CLOSED}" \
@@ -395,8 +395,13 @@ spec:
           # (not its own port — it must be publicly reachable on the same origin
           # as the OAuth metadata clients discover it through). Requires
           # authorizer_url; guarded at render time above.
+          {{- if .Values.authorizer.mcp_enabled }}
+          # Set ONLY when enabled. An empty value would still expand to the flag
+          # on image tags that predate it, which is a boot failure rather than a
+          # no-op — see the entrypoint's ${MCP_ENABLED:+...} guard.
           - name: "MCP_ENABLED"
-            value: {{ include "authorizer.bool" (list .Values.authorizer.mcp_enabled false) | quote }}
+            value: "true"
+          {{- end }}
           - name: "GRPC_INSECURE"
             value: {{ .Values.authorizer.grpc_insecure | default false | toString | quote }}
           {{- if .Values.authorizer.grpc_tls_cert }}


### PR DESCRIPTION
**Fixes a regression in already-merged code.** Deployments from this chart currently fail to start.

## What broke

The MCP change added the flag unconditionally:

```
--mcp-enabled="${MCP_ENABLED:-false}"
```

But the base image is pinned to `2.4.0-rc.18`, which predates `--mcp-enabled`. So the binary exits immediately:

```
Error: unknown flag: --mcp-enabled
```

**This happens even with `MCP_ENABLED` unset**, because the flag is still passed as `--mcp-enabled=false`. Every deployment from this chart is affected, whether or not the operator wants MCP.

## The fix

`${MCP_ENABLED:+--mcp-enabled="$MCP_ENABLED"}` — shell parameter expansion that emits **nothing** when the variable is unset or empty.

That has the right shape independent of the pin: an operator who never enables MCP is unaffected by the flag existing at all, and one who opts in gets a clear `unknown flag` error if their image predates support, rather than a silent no-op.

## Verified by actually running it

| Scenario | Result |
|---|---|
| `MCP_ENABLED` unset (the default) | Container **healthy**, `/health` 200 |
| `MCP_ENABLED=true` on the old pinned base | Fails loudly with `unknown flag` — correct and diagnosable |

Found by building the image and booting it, which is the only thing that catches this — the chart renders and lints cleanly either way.

## Follow-up

Once 2.4.0 ships with the flag, bump the pinned base image; `MCP_ENABLED=true` then works. Until then it correctly refuses rather than pretending.